### PR TITLE
fix: correct scummvm.zip and cpc464.rom MD5 in retroarch manifest

### DIFF
--- a/retroarch/component_manifest.json
+++ b/retroarch/component_manifest.json
@@ -3819,14 +3819,14 @@
         },
         {
           "filename": "scummvm.zip",
-          "md5": "a17e0e0150155400d8cced329563d9c8",
+          "md5": "368bdb1816a02640f873310faa9dedf7",
           "system": "scummvm",
           "description": "SCUMMVM Assets",
           "required": "Yes, for RetroArch ScummVM Core"
         },
         {
           "filename": "cpc464.rom",
-          "md5": "a17e0e0150155400d8cced329563d9c8",
+          "md5": "a993f85b88ac4350cf4d41554e87fe4f",
           "system": "amstradcpc",
           "description": "Amstrad CPC 464 BIOS"
         },


### PR DESCRIPTION
Two wrong MD5 hashes in the retroarch manifest.

| File | Current MD5 | Correct MD5 |
|------|-------------|-------------|
| scummvm.zip | a17e0e0150155400d8cced329563d9c8 | 368bdb1816a02640f873310faa9dedf7 |
| cpc464.rom | a17e0e0150155400d8cced329563d9c8 | a993f85b88ac4350cf4d41554e87fe4f |

`a17e0e01...` is from an old 9.5MB buildbot ScummVM.zip. Current buildbot build is 79MB. Same hash was copied to cpc464.rom (16KB ROM, cannot match a 79MB ZIP).

Correct cpc464.rom MD5 verified against Batocera and libretro System.dat. Stale hash originates from [System.dat](https://github.com/libretro/libretro-database/blob/master/dat/System.dat).